### PR TITLE
Multiple travis-ci configuration improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: python
 python: 3.6
-install: "pip install Lektor==3.1.1"
-script: "lektor build && lektor deploy ghpages"
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.cache/lektor/builds
+install: "pip install -r requirements.txt"
+script: "lektor build"
+deploy:
+  provider: script
+  script: "lektor deploy ghpages"
+  on:
+    branch: edition


### PR DESCRIPTION
- Install pinned requirements.txt instead of only pinned
  Lektor version. This makes the builds repeatable and
  ensures local and travis packages are the same.

- Add pip and lektor pages cache. This makes builds much faster.

- Restrict deployment to `edition` branch. Previously
  deployment was being tried for all PRs, but failing if
  it was not from a branch in the same repo, since travis secret
  variables are only made available to builds from branches in the same
  repo.

See https://www.getlektor.com/docs/deployment/travisci/.