### PR TITLE
Publish membership registration opening

### DIFF
--- a/content/blog/association-membership/contents.lr
+++ b/content/blog/association-membership/contents.lr
@@ -1,0 +1,38 @@
+title: PyBCN association membership registration is now open!
+---
+author: pybcn
+---
+body:
+
+Hi!
+
+We're glad to announce that [the Python Barcelona association (PyBCN)](https://pybcn.org/association/info) membership registration is finally open :)
+[Join us](https://pybcn.org/association/become-a-member) and help us organize bigger and better Python related events!
+
+PyBCN is a **non-profit organization** with more than 10 years of history, focused on increasing the usage and knowledge of the Python programming language.
+By becoming a member, you'll support the association's activities and programs, helping us not only to increase the number of activities, but also to improve them (i.e. getting a better recording system for the meetups) and cover basic expenses (domains, meetup fees...).
+
+As a member you must:
+- comply with the association [Code of Conduct](https://pybcn.org/coc/)
+- pay a yearly membership fee. The current yearly fee is 20 euros.
+
+As a member, you can:
+- Have a voice and vote in our general assemblies,
+- Participate in our board elections,
+- Receive information about the activities of the association,
+- Become part of the working groups,
+- Ask questions abouts the association management,
+- Make use of the common services that the association establishes or has at your disposal,
+- Be heard before the adoption of disciplinary measures,
+- Participate in the government and the management of the association, its services and activities,
+- Have a copy of the statutes, and
+- Consult the association's books.
+
+We are really excited with this new step in PyBCN's life, and we hope that it will allow us to grow, not only in members, but also in activities and goals.
+
+Thank you!
+
+---
+excerpt: Join us as official member and help all PyBCN activities!
+---
+pub_date: 2019-05-26

--- a/templates/header.html
+++ b/templates/header.html
@@ -57,6 +57,7 @@
                                                 ['/pyday-bcn-2018', 'PyDay BCN 2018'],
                                                 ['/coc', 'Code of Conduct'],
                                                 ['/job-offers', 'Job Offers'],
+					        ['/association/info', 'Association'],
                                             ] %}
                                                 <li{% if this.is_child_of(href) %} class="active"{% endif %}>
                                                     <a href="{{ href|url }}">{{ title }}</a>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -56,6 +56,12 @@
                         </h3>
                     </div>
 
+                    <div class="widget" >
+			<h3 class="widget-title" style="text-align: center">
+                        <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
+                        <a href="/association/become-a-member/">Become a member</a>
+			</h3>
+		    </div>
                     {% if not this.is_child_of('/') %}
                     <div class="widget" >
                         <h3 class="widget-title">


### PR DESCRIPTION
This change includes all necessary changes to publish and announce membership registration opening:
- add a link to the association information page in the main menu
- add a CTA for membership registration
- add a post announcing the membership registration opening.

After this gets merged, the content of the post could be used for announcing through the mailing list.