### PR TITLE
Make PyDay BCN 2019 page available in header menu

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -54,7 +54,7 @@
                                                 ['/coding-dojos', 'Coding Dojos'],
                                                 ['/pyladies-bcn', 'PyLadies BCN'],
                                                 ['/pydatabcn-2017', 'PyDataBCN 2017'],
-                                                ['/pyday-bcn-2018', 'PyDay BCN 2018'],
+                                                ['/pyday-bcn-2019', 'PyDay BCN 2019'],
                                                 ['/coc', 'Code of Conduct'],
                                                 ['/job-offers', 'Job Offers'],
 					        ['/association/info', 'Association'],


### PR DESCRIPTION
This way, the new page will be reachable through navigation.