### PR TITLE
Small improvements for PyDay BCN 2019 gold and coffee sponsors

### DIFF
--- a/content/pyday-bcn-2019/contents.lr
+++ b/content/pyday-bcn-2019/contents.lr
@@ -67,12 +67,14 @@ Check out [our sponsoring document](https://drive.google.com/file/d/1qRUUnO-DskQ
 
 ## Gold
 <center>
-<img src="thoughtworks.png" style="width: 150px; margin: 20px 20px auto;">
+<img src="thoughtworks.png" style="width: 150px; margin: 20px 0px auto;">
 <img src="bmat.png" style="width: 70px; margin: 20px 20px auto;">
 <img src="holaluz.png" style="width: 80px; margin: 20px 20px auto;">
+<br />
 <img src="travelperk.png" style="width: 150px; margin: 20px 20px auto;">
-<img src="elastic.png" style="width: 110px; margin: 20px 20px auto;">
+<img src="elastic.png" style="width: 110px; margin: 20px 10px auto;">
 <img src="verse.png" style="width: 110px; margin: 20px 20px auto;">
+<br />
 <img src="fundacion-ci.jpg" style="width: 110px; margin: 20px 20px auto;">
 </center>
 

--- a/content/pyday-bcn-2019/contents.lr
+++ b/content/pyday-bcn-2019/contents.lr
@@ -62,7 +62,7 @@ Check out [our sponsoring document](https://drive.google.com/file/d/1qRUUnO-DskQ
 
 ## Coffee Sponsor
 <center>
-<img src="affectv.png" style="width: 150px; margin: 20px 20px auto;">
+<img src="affectv.png" style="width: 100px; margin: 20px 20px auto;">
 </center>
 
 ## Gold


### PR DESCRIPTION
So far, there are two changes:
- Fix PyDay BCN 2019 gold sponsors alignment and lines
- Reduce PyDay BCN 2019 Coffee sponsor logo size
![2019-10-15-214920_2560x2520_scrot](https://user-images.githubusercontent.com/2912400/66865583-cf634380-ef97-11e9-93e9-ee100c5254db.png)
