### PR TITLE
Add redirects for old site's URLs to new ones

### DIFF
--- a/content/events/pyday_bcn/pyday_bcn_2020.md
+++ b/content/events/pyday_bcn/pyday_bcn_2020.md
@@ -6,6 +6,8 @@ menu:
   main:
     parent: 'PyDay BCN'
 weight: 1
+aliases:
+- /pyday-bcn-2020
 heroBackground: https://images.unsplash.com/photo-1504384764586-bb4cdc1707b0?ixlib=rb-1.2.1&auto=format&fit=crop&w=1350&q=80
 
 layout: event

--- a/content/pybcn_association/coc.md
+++ b/content/pybcn_association/coc.md
@@ -5,6 +5,8 @@ menu:
   main:
     parent: 'The association'
 weight: 4
+aliases:
+- /coc
 
 layout: single
 heroBackground: https://source.unsplash.com/LjqARJaJotc/1600x400

--- a/content/pybcn_association/job-offers.md
+++ b/content/pybcn_association/job-offers.md
@@ -5,6 +5,8 @@ menu:
   main:
     parent: 'How to collaborate'
 weight: 5
+aliases:
+- /job-offers
 heroBackground: https://source.unsplash.com/vzfgh3RAPzM/1600x400
 ---
 


### PR DESCRIPTION
These pages had different URLs in the old site, and we are still
sharing them as they were. This is adding aliases, i.e. HTTP 301
redirects, to the corresponding pages.