### PR TITLE
Introduce job-offers-info shortcode

### DIFF
--- a/content/pybcn_association/job-offers.md
+++ b/content/pybcn_association/job-offers.md
@@ -12,25 +12,7 @@ heroBackground: https://source.unsplash.com/vzfgh3RAPzM/1600x400
 
 All job offers are sent to the subscribers of the mailing list.
 
-To **check** past job offers, go to the [Mailing List Archive](https://www.meetup.com/python-barcelona/messages/archive/).
-
-To **publish** a new job offer:
-
-* Send it to pybcn+jobs at googlegroups.com.
-* Subject: *Job offer: {POSITION} at {COMPANY}*, where *{POSITION}* is the position of the job offer, and *{COMPANY}* is the name of your company.
-* For the body, feel free to check other job offers as inspiration.
-* If the rules are met, we'll publish the offer!
-
-All job offers **must** follow these rules:
-
-1. Be related to Python.
-2. Contain a good job description.
-3. Provide the name of the company, and direct company contact info.
-4. Provide a salary range.
-
-As your email will be sent to the Meetup.com's mailing list, it's important to notice it removes all mail addresses and attachments, so, please avoid these.
+{{% job-offers/job-offers-info mailing_list_url="https://www.meetup.com/python-barcelona/messages/archive/" mail="pybcn+jobs at googlegroups.com" %}}).
 
 To get more visibility of what you do, consider [giving a talk](/pybcn_association/propose-a-talk/) or offering to host the meetup!
-
-**Disclaimer**: We ban cheaters. Don't post offers in comments, events, or discussions!
 

--- a/content/pyladies_bcn/job-offers.md
+++ b/content/pyladies_bcn/job-offers.md
@@ -11,23 +11,7 @@ heroBackground: https://source.unsplash.com/vzfgh3RAPzM/1600x400
 Is your company offering jobs or scholarships? Share your offers with us and we'll forward it to the subscribers of the PyLadiesBCN mailing list.
 Alternatively, you can also post them to the [general PyBCN community](/pybcn_association/job-offers).
 
-To **check** past job offers, go to the <a href="https://www.meetup.com/pyladies-bcn/messages/archive/" target="_blank">Mailing List Archive</a>.
-
-To **publish** a new job offer:
-
-* Send it to pyladies-bcn+jobs at googlegroups.com.
-* Subject: *Job offer: {POSITION} at {COMPANY}*, where *{POSITION}* is the position of the job offer, and *{COMPANY}* is the name of your company.
-* For the body, feel free to check other job offers as inspiration.
-* If the rules are met, we'll publish the offer!
-
-All job offers **must** follow these rules:
-
-1. Be related to Python.
-2. Contain a good job description.
-3. Provide the name of the company, and direct company contact info.
-4. Provide a salary range.
+{{% job-offers/job-offers-info mailing_list_url="https://www.meetup.com/pyladies-bcn/messages/archive/" mail="pyladies-bcn+jobs at googlegroups.com" %}}
 
 To get more visibility of what you do, consider [organizing a workshop](/pyladies_bcn/call-for-proposals/) or offering to host the meetup!
-
-**Disclaimer**: We ban cheaters. Don't post offers in comments, events, or discussions!
 

--- a/layouts/shortcodes/job-offers/job-offers-info.html
+++ b/layouts/shortcodes/job-offers/job-offers-info.html
@@ -1,0 +1,21 @@
+To **check** past job offers, go to the [Mailing List Archive]({{ .Get "mailing_list_url" }}).
+
+To **publish** a new job offer:
+
+* Send it to {{ .Get "mail" }}.
+* Subject: *Job offer: {POSITION} at {COMPANY}*, where *{POSITION}* is the position of the job offer, and *{COMPANY}* is the name of your company.
+* For the body, feel free to check other job offers as inspiration.
+* If the rules are met, we'll publish the offer!
+
+All job offers **must** follow these rules:
+
+1. Be related to Python.
+2. Contain a good job description.
+3. Provide the name of the company, and direct company contact info.
+4. Provide a salary range.
+
+**Disclaimers**:
+
+* As your email will be sent to the Meetup.com's mailing list, it's important to notice it removes all mail addresses and attachments, so, please avoid these or use substitutes, like "mail at domain", instead of "mail@domain", or a URL to the application page
+.
+* We ban cheaters. Don't post offers in comments, events, or discussions!


### PR DESCRIPTION
By using shortcodes, the job offers rules, procedure and disclaimer
can be easily shared between both PyBCN and PyLadiesBCN job offers'
pages. This makes these pages homogeneus and easier to modify.

This change also reorganizes the content of the pages a little bit to
provide a clear view of the details to consider when publishing.

#