### PR TITLE
Upgrade Ubuntu version used in GH Actions to 22.04

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This should prevent possible security issues and remove confusing warning messages from our Actions logs.