### PR TITLE
Upgade hugo to latest binary

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.75.1'
+          hugo-version: '0.104.3'
           extended: true
 
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+bin/hugo
+public/**


### PR DESCRIPTION
I've already tested this is apparently working fine locally.
Hopefully this will solve the Dependabot alert on node-sass
certificate.

Also, the first commit, prevents unwanted files to be pushed to the
repository.

This needs to be rebased once #120 is merged.