### PR TITLE
Use newer version of actions/checkout (v3)

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod


### PR DESCRIPTION
This should already use NodeJS 16 instead of NodeJS 12, so the [GH Actions complain](https://github.com/pybcn/pybcn.github.io/actions/runs/3307444065)
about this should be off.

See [GH article about NodeJS 12 deprecation](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) for reference