### PR TITLE
Upgrade to Hugo 0.139.4 and stop using GAnalytics.

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -3,8 +3,8 @@
 set -euo pipefail
 
 function install_hugo() {
-  echo -n "Installing Hugo 0.123.8... "
-  pip install hugo=="0.123.8"
+  echo -n "Installing Hugo 0.139.4... "
+  pip install hugo=="0.139.4"
   echo "OK!"
 }
 

--- a/themes/pybcn_theme/layouts/partials/head.html
+++ b/themes/pybcn_theme/layouts/partials/head.html
@@ -24,8 +24,6 @@
    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
   {{ end -}}
 
-  {{ template "_internal/google_analytics_async.html" . }}
-
   {{ if .Site.Params.cookie_consent_info_url }}
     {{ partial "cookie-consent.html" . }}
   {{ end }}


### PR DESCRIPTION
For some reason it fails when trying to load the Google Analytics partial with the new version. However in the last Assembly we said we want to remove Google Analytics, so removing it is the simple solution.