### PR TITLE
Deploy using Hugo 0.139.4.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.104.3'
+          hugo-version: '0.139.4'
           extended: true
 
       - name: Build


### PR DESCRIPTION
We updated the Hugo version recently but we were still deploying with the old one via GH Actions. Fix this.